### PR TITLE
Fix "Jump on B" in general Amiga options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -616,7 +616,7 @@ def generateCoreSettings(coreSettings, system, rom):
             coreSettings.save('puae_mouse_speed', system.config['mouse_speed'])
         else:
             coreSettings.save('puae_mouse_speed', '"200"')
-        # Jump on B
+        # Jump on A
         if system.isOptSet('pad_options'):
             coreSettings.save('puae_retropad_options', system.config['pad_options'])
         elif system.name == 'amigacdtv':

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3677,12 +3677,6 @@ libretro:
                     "150%":       150
                     "170%":       170
                     "200%":       200
-            pad_options:
-                prompt:      JUMP ON B
-                description: Makes second fire button press up instead.
-                choices:
-                    "Off":    disabled
-                    "On":     jump
       systems:
             amiga500:
                 cfeatures:
@@ -3714,6 +3708,13 @@ libretro:
                         choices:
                             "Off":    disabled
                             "On":     enabled
+                    pad_options:
+                        group: ADVANCED OPTIONS
+                        prompt:      JUMP ON A
+                        description: Makes second fire button press up instead.
+                        choices:
+                            "Off":    disabled
+                            "On":     jump
                     controller1_puae:
                         prompt:      CONTROLLER 1 TYPE
                         description: Select controller type for Amiga P1.
@@ -3764,7 +3765,7 @@ libretro:
                             "On":     config
                     pad_options:
                         group: ADVANCED OPTIONS
-                        prompt:      JUMP ON B
+                        prompt:      JUMP ON A
                         description: Makes second fire button press up instead.
                         choices:
                             "Off":    disabled


### PR DESCRIPTION
- Removed from general Amiga options and added to A500 options, because with the "group" feature it duplicates this option in ungrouped general options and advanced options
- "Jump on B" changed to "Jump on A", because you using A button to UP, not B button.