### PR TITLE
AWGL Options for ES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators.piboy/awgl/awglGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators.piboy/awgl/awglGenerator.py
@@ -3,6 +3,7 @@
 import Command
 from generators.Generator import Generator
 import controllersConfig
+import configparser
 import os
 
 class AwglGenerator(Generator):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators.piboy/awgl/awglGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators.piboy/awgl/awglGenerator.py
@@ -32,7 +32,66 @@ class AwglGenerator(Generator):
         if (rom.__contains__("Win31")):
             game = "--datapath=/userdata/roms/awgl/Win31"
 
-        commandArray = ["awgl", game, "--language=us", rendr]
+        commandArray = ["awgl", game]
+
+        # Rendering mode
+        if system.isOptSet("awgl_render"):
+            if system.config['awgl_render'] == 'original':
+                commandArray.append("--render=original")
+            elif system.config['awgl_render'] == 'software':
+                commandArray.append("--render=software")
+            elif system.config['awgl_render'] == 'gl':
+                commandArray.append("--render=gl")
+        else:
+            commandArray.append("--render=original")
+
+        # Screen mode
+        if system.isOptSet("awgl_fullscreen"):
+            if system.config['awgl_fullscreen'] == 'stretched':
+                commandArray.append("--fullscreen")
+            elif system.config['awgl_fullscreen'] == 'wide':
+                commandArray.append("--fullscreen-ar")
+        else:
+            commandArray.append("--fullscreen")
+
+        # Audio mode
+        if system.isOptSet("awgl_audio"):
+            if system.config['awgl_audio'] == 'original':
+                commandArray.append("--audio=original")
+            elif system.config['awgl_audio'] == 'remastered':
+                commandArray.append("--audio=remastered")
+        else:
+            commandArray.append("--audio=original")
+
+        # Language
+        if system.isOptSet("awgl_language"):
+            if system.config['awgl_language'] == 'us':
+                commandArray.append("--language=us")
+            elif system.config['awgl_language'] == 'fr':
+                commandArray.append("--language=fr")
+            elif system.config['awgl_language'] == 'de':
+                commandArray.append("--language=de")
+            elif system.config['awgl_language'] == 'es':
+                commandArray.append("--language=es")
+            elif system.config['awgl_language'] == 'it':
+                commandArray.append("--language=it")
+        else:
+            commandArray.append("--language=us")
+
+        # Game difficulty
+        if system.isOptSet("awgl_difficulty"):
+            if system.config['awgl_difficulty'] == 'easy':
+                commandArray.append("--difficulty=easy")
+            elif system.config['awgl_difficulty'] == 'normal':
+                commandArray.append("--difficulty=normal")
+            elif system.config['awgl_difficulty'] == 'hard':
+                commandArray.append("--difficulty=hard")
+        else:
+            commandArray.append("--difficulty=easy")
+
+        # EGA screen mode for DOS
+        if system.isOptSet("awgl_egados") and system.config['awgl_egados'] == 'enabled':
+            commandArray.append("--ega-palette")
 
         return Command.Command(
             array=commandArray,

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/awgl/awglGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/awgl/awglGenerator.py
@@ -3,6 +3,7 @@
 import Command
 from generators.Generator import Generator
 import controllersConfig
+import configparser
 import os
 
 class AwglGenerator(Generator):
@@ -32,7 +33,66 @@ class AwglGenerator(Generator):
         if (rom.__contains__("Win31")):
             game = "--datapath=/userdata/roms/awgl/Win31"
 
-        commandArray = ["awgl", game, "--language=us", rendr]
+        commandArray = ["awgl", game]
+
+        # Rendering mode
+        if system.isOptSet("awgl_render"):
+            if system.config['awgl_render'] == 'original':
+                commandArray.append("--render=original")
+            elif system.config['awgl_render'] == 'software':
+                commandArray.append("--render=software")
+            elif system.config['awgl_render'] == 'gl':
+                commandArray.append("--render=gl")
+        else:
+            commandArray.append("--render=original")
+
+        # Screen mode
+        if system.isOptSet("awgl_fullscreen"):
+            if system.config['awgl_fullscreen'] == 'stretched':
+                commandArray.append("--fullscreen")
+            elif system.config['awgl_fullscreen'] == 'wide':
+                commandArray.append("--fullscreen-ar")
+        else:
+            commandArray.append("--fullscreen")
+
+        # Audio mode
+        if system.isOptSet("awgl_audio"):
+            if system.config['awgl_audio'] == 'original':
+                commandArray.append("--audio=original")
+            elif system.config['awgl_audio'] == 'remastered':
+                commandArray.append("--audio=remastered")
+        else:
+            commandArray.append("--audio=original")
+
+        # Language
+        if system.isOptSet("awgl_language"):
+            if system.config['awgl_language'] == 'us':
+                commandArray.append("--language=us")
+            elif system.config['awgl_language'] == 'fr':
+                commandArray.append("--language=fr")
+            elif system.config['awgl_language'] == 'de':
+                commandArray.append("--language=de")
+            elif system.config['awgl_language'] == 'es':
+                commandArray.append("--language=es")
+            elif system.config['awgl_language'] == 'it':
+                commandArray.append("--language=it")
+        else:
+            commandArray.append("--language=us")
+
+        # Game difficulty
+        if system.isOptSet("awgl_difficulty"):
+            if system.config['awgl_difficulty'] == 'easy':
+                commandArray.append("--difficulty=easy")
+            elif system.config['awgl_difficulty'] == 'normal':
+                commandArray.append("--difficulty=normal")
+            elif system.config['awgl_difficulty'] == 'hard':
+                commandArray.append("--difficulty=hard")
+        else:
+            commandArray.append("--difficulty=easy")
+
+        #EGA screen mode for DOS
+        if system.isOptSet("awgl_egados") and system.config['awgl_egados'] == 'true':
+            commandArray.append("--ega-palette")
 
         return Command.Command(
             array=commandArray,

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/awgl/awglGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/awgl/awglGenerator.py
@@ -90,8 +90,8 @@ class AwglGenerator(Generator):
         else:
             commandArray.append("--difficulty=easy")
 
-        #EGA screen mode for DOS
-        if system.isOptSet("awgl_egados") and system.config['awgl_egados'] == 'true':
+        # EGA screen mode for DOS
+        if system.isOptSet("awgl_egados") and system.config['awgl_egados'] == 'enabled':
             commandArray.append("--ega-palette")
 
         return Command.Command(

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7673,6 +7673,52 @@ alephone:
 awgl:
   features: [padtokeyboard]
   shared: [videomode, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  cfeatures:
+        awgl_difficulty:
+            prompt:      GAME DIFFICULTY
+            description: Select game difficulty.
+            choices:
+                "Easy":           easy
+                "Normal":         normal
+                "Hard":           hard
+        awgl_language:
+            prompt:      GAME LANGUAGE
+            description: Select game language.
+            choices:
+                "English":        us
+                "Français":       fr
+                "Deutsch":        de
+                "Español":        es
+                "Italiano":       it
+        awgl_render:
+            group: ADVANCED OPTIONS
+            prompt:      GAME RENDERING
+            description: Select rendering mode.
+            choices:
+                "Original":       original
+                "Software":       software
+                "OpenGL":         gl
+        awgl_fullscreen:
+            group: ADVANCED OPTIONS
+            prompt:      FULLSCREEN MODE
+            description: Select fullscreen mode.
+            choices:
+                "Stretched (640x480)":      stretched
+                "Widescreen (16:10)":       wide
+        awgl_audio:
+            group: ADVANCED OPTIONS
+            prompt:      SOUND EFFECTS MODE
+            description: Select sound effects mode.
+            choices:
+                "Original":       original
+                "Remastered":     remastered
+        awgl_egados:
+            group: ADVANCED OPTIONS
+            prompt:      EGA GRAPHICS MODE
+            description: Simulate the EGA graphics mode (works only with DOS version).
+            choices:
+                "On":             enabled
+                "Off":            disabled
 
 bermuda:
   features: [padtokeyboard]


### PR DESCRIPTION
Another World GL Options for ES:

- Game difficulty
- Game language
- Ingame audio mode (Original or remastered)
- Rendering mode
- Fullscreen mode (Stretched=640x480 or widescreen)
- EGA screen mode (only works for DOS version)

OpenGL doesn't work. Crashes to ES (missing flag on make?)

es_launch_stderr.log:

```
killall: evmapy: no process killed
2022-03-17 14:26:46,310 ERROR (emulatorlauncher:666):runCommand ERROR: GL_MAX_COLOR_ATTACHMENTS is 0!
```

