### PR TITLE
New preset added in Pinball Mode for PUAE

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -457,6 +457,37 @@ def generateCoreSettings(coreSettings, system, rom):
                     'start': "RETROK_RETURN",}
                 for key in uae_mapping:
                     coreSettings.save('puae_mapper_' + key, uae_mapping[key])
+            elif system.isOptSet('puae_pinball_mode') and system.config['puae_pinball_mode'] == "modern_alt":
+                uae_mapping = { 'aspect_ratio_toggle': "---",
+                    'mouse_toggle': "RETROK_RCTRL",
+                    'statusbar': "RETROK_F11",
+                    'vkbd': "---",
+                    'reset': "---",
+                    'zoom_mode_toggle': "RETROK_F12",
+                    'down': "---",
+                    'left': "---",
+                    'a': "---",
+                    'b': "---",
+                    'x': "RETROK_SPACE",
+                    'y': "RETROK_DOWN",
+                    'l': "---",
+                    'l2': "RETROK_LALT",
+                    'l3': "SWITCH_JOYMOUSE",
+                    'ld': "---",
+                    'll': "---",
+                    'lr': "---",
+                    'lu': "---",
+                    'r': "---",
+                    'r2': "RETROK_RALT",
+                    'r3': "TOGGLE_STATUSBAR",
+                    'rd': "---",
+                    'rl': "---",
+                    'rr': "---",
+                    'ru': "---",
+                    'select': "TOGGLE_VKBD",
+                    'start': "RETROK_RETURN",}
+                for key in uae_mapping:
+                    coreSettings.save('puae_mapper_' + key, uae_mapping[key])
             elif system.isOptSet('puae_pinball_mode') and system.config['puae_pinball_mode'] == "classic":
                 uae_mapping = { 'aspect_ratio_toggle': "---",
                     'mouse_toggle': "RETROK_RCTRL",

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3822,9 +3822,10 @@ libretro:
                         prompt:      PINBALL MAPPING MODE
                         description: Use to play pinball games with correct mapping.
                         choices:
-                            "Off":      disabled
-                            "Modern":   modern
-                            "Classic":  classic
+                            "Off":                  disabled
+                            "Modern":               modern
+                            "Modern Alternative":   modern_alt
+                            "Classic":              classic
             amigacd32:
                 cfeatures:
                     puae_cd_startup_delayed_insert:


### PR DESCRIPTION
New preset added called "Modern Alternative" for PUAE. Cool working with Piboy too.
In this preset there aren't mouse buttons mapped, but you can use the mouse mode on your gamepad/handheld by using L3 for switch Joystick/Mouse mode. This is available for all modes.

L2: Left Alt (Left flipper)
R2: Right Alt (Right flipper)
Y Button: Down Arrow (Launch ball)
X Button: Space (Shaking table and tilt)