### PR TITLE
Fix incorrect ports closing 

### DIFF
--- a/package/batocera/ports/openjazz/openjazz.keys
+++ b/package/batocera/ports/openjazz/openjazz.keys
@@ -16,7 +16,7 @@
                 "start"
             ],
             "type": "exec",
-            "target": "killall -9 OpenJazz && reset"
+            "target": "killall -15 OpenJazz"
         },
         {
             "trigger": "up",

--- a/package/batocera/ports/rott/rott.keys
+++ b/package/batocera/ports/rott/rott.keys
@@ -3,7 +3,7 @@
         {
             "trigger": ["hotkey", "start"],
             "type": "exec",
-            "target": "killall -9 rott-darkwar && reset"
+            "target": "killall -15 rott-darkwar"
         },
         {
             "trigger": "up",


### PR DESCRIPTION
With "killall -9" they stays in background for unknown reason, but with "killall -15" they're closing correctly.