### PR TITLE
Bump Libretro VICE and PUAE 

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-puae/libretro-puae.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-puae/libretro-puae.mk
@@ -3,8 +3,8 @@
 # libretro-puae
 #
 ################################################################################
-# Version: Commits on Mar 31, 2022
-LIBRETRO_PUAE_VERSION = 022c82b63ccb0d76a35803e52fa3458542f7ebf0
+# Version: Commits on Apr 04, 2022
+LIBRETRO_PUAE_VERSION = 8c44289acfd5e622963aed314512611a7a8301ef
 LIBRETRO_PUAE_SITE = $(call github,libretro,libretro-uae,$(LIBRETRO_PUAE_VERSION))
 LIBRETRO_PUAE__LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
@@ -3,8 +3,8 @@
 # libretro-vice
 #
 ################################################################################
-# Version: Commits on Mar 30, 2022
-LIBRETRO_VICE_VERSION = c509d3e243faa9197ddef7caaee8d7a61462418d
+# Version: Commits on Apr 04, 2022
+LIBRETRO_VICE_VERSION = 6ac90f1d07322ac927f3ad108af85a81259bebb3
 LIBRETRO_VICE_SITE = $(call github,libretro,vice-libretro,$(LIBRETRO_VICE_VERSION))
 LIBRETRO_VICE_LICENSE = GPLv2
 


### PR DESCRIPTION
I've request to sonninnos to add these new functions
- Added OSD message when switching ports to VICE without enabling the statusbar
- Added OSD message when switching joy-mouse to PUAE without enabling the statusbar