### PR TITLE
PUAE options 

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3917,8 +3917,7 @@ libretro:
                 choices:
                     "Normal":                       normal
                     "More compatible":              compatible
-                    "Cycle-exact (DMA/Memory)":     memory
-                    "Cycle-exact (Full)":           exact
+                    "Cycle-exact":                  exact
             cpu_multiplier:
                 prompt:      CPU CLOCK
                 description: Works with 'Cycle-exact' mode and for a few games.

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3160,20 +3160,21 @@ amigademo:
   group:      amiga
   emulators:
     fsuae:
-      A500:   { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
-      A500+:  { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
-      A600:   { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
-      A1000:  { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
-      A3000:  { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
-      A1200:  { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
-      A4000:  { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A500:      { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A500+:     { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A600:      { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A1000:     { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A3000:     { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A1200:     { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
+      A4000:     { requireAnyOf: [BR2_PACKAGE_FSUAE]         }
     amiberry:
-      A500:   { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
-      A500+:  { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
-      A1200:  { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
-      A4000:  { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
+      A500:      { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
+      A500+:     { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
+      A1200:     { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
+      A4000:     { requireAnyOf: [BR2_PACKAGE_AMIBERRY], incompatible_extensions: [m3u] }
     libretro:
-      puae:   { requireAnyOf: [BR2_PACKAGE_LIBRETRO_PUAE] }
+      puae:      { requireAnyOf: [BR2_PACKAGE_LIBRETRO_PUAE] }
+      puae2021:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_PUAE] }
 
 alephone:
   name:       Marathon Trilogy


### PR DESCRIPTION
- Removed Cycle Exact (DMA/Memory) to puae2021. It's available only with standard PUAE
- Added puae2021 to Amiga Demos