### PR TITLE
Added a music path for the Bermuda port.

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/bermuda/bermudaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/bermuda/bermudaGenerator.py
@@ -9,7 +9,7 @@ class BermudaGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, guns, gameResolution):
         os.chdir("/userdata/roms/ports/bermuda")
-        commandArray = ["bermuda", "--datapath=/userdata/roms/ports/bermuda", "--savepath=/userdata/saves/bermuda", "--fullscreen"]
+        commandArray = ["bermuda", "--datapath=/userdata/roms/ports/bermuda", "--musicpath=/userdata/roms/ports/bermuda/MUSIC", "--savepath=/userdata/saves/bermuda", "--fullscreen"]
 
         if system.isOptSet("bermuda_aspect"):
             if system.config['bermuda_aspect'] == '1':

--- a/package/batocera/emulationstation/batocera-es-system/roms/ports/bermuda/_Readme.txt
+++ b/package/batocera/emulationstation/batocera-es-system/roms/ports/bermuda/_Readme.txt
@@ -1,2 +1,2 @@
 This port requires a copy of the original datafiles from the Windows release of Bermuda Syndrome.
-You will need to copy all files from the DATA directory into this directory.
+You will need to copy all files from the DATA directory into this directory. Optional music files should be copied to a MUSIC subfolder of this directory.


### PR DESCRIPTION
Very small modification for the Bermuda Syndrome port. This allows the optional music to be stored in the /userdata/roms/ports/bermuda/MUSIC folder.  Currently it must be put into the /userdata/system/MUSIC folder to make it work.  This is because if the musicpath is not set it defaults to the the local MUSIC folder from which it is ran.